### PR TITLE
first pass on the NFT contract

### DIFF
--- a/contracts/BaseErc721.sol
+++ b/contracts/BaseErc721.sol
@@ -1,0 +1,48 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+
+contract BaseErc721 is ERC721, Ownable {
+
+    uint256 public tokenId;
+    string public ipfsCID;
+
+    //whitelist merkle tree described at https://medium.com/@ItsCuzzo/using-merkle-trees-for-nft-whitelists-523b58ada3f9
+    //merkle root provided by NFT creator on deployment via constructor
+    bytes32 public merkleRootWhitelist;
+    //record of addresses that have previously claimed the NFT
+    mapping(address => bool) public whitelistClaimed;
+
+    event tokenMinted(uint256, address);
+
+
+    constructor(string memory _name, string memory _symbol, string memory _ipfsCID, bytes32 _merkleRoot ) ERC721(_name, _symbol) {
+        tokenId = 0;
+        ipfsCID = _ipfsCID;
+        merkleRootWhitelist = _merkleRoot;
+
+    }
+
+    function claim(bytes32[] calldata _merkleProof) public {
+
+        //verify the wallet has not already claimed a NFT
+        require(!whitelistClaimed[msg.sender], "This address has already claimed the NFT");
+
+        //verify merkle proof provided by the UI on claiming
+        bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
+        require(MerkleProof.verify(_merkleProof, merkleRootWhitelist, leaf), "Invalid proof." );
+
+        //update claimed list
+        whitelistClaimed[msg.sender] = true;
+
+        //mint NFT and increment tokenId
+        _safeMint(msg.sender, tokenId);
+        tokenId+=1;
+
+
+    }
+    
+}


### PR DESCRIPTION
added the NFT contract with a NFT "claim" function implementing the merkle tree whitelist mint described [here](https://medium.com/@ItsCuzzo/using-merkle-trees-for-nft-whitelists-523b58ada3f9). The front-end still needs to implement this utility.

I haven't tested the contract yet, so it's best viewed as a first draft. 

Since we're (currently) having each NFT contract deploy as one static image for all tokens, I've included a public string variable in the contract (ipfsCID), which will be the record for the IPFS CID passed via the constructor on deployment. 